### PR TITLE
Add workday counter script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # play
-play with gpt
+
+Small experiments with GPT.
+
+## Workday Counter
+
+This repo includes a simple script `workdays.py` for calculating how many working days are in each month of a given year. It accounts for Chinese legal holidays and weekend adjustments using the [`chinesecalendar`](https://github.com/holidays-libraries/chinesecalendar) library.
+
+### Usage
+
+```bash
+pip install -r requirements.txt
+python workdays.py 2024       # calculate for all months in 2024
+python workdays.py 2024 -m 5  # calculate only for May 2024
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+chinesecalendar

--- a/workdays.py
+++ b/workdays.py
@@ -1,0 +1,40 @@
+from datetime import date, timedelta
+import argparse
+import sys
+
+import chinesecalendar as cc
+
+
+def count_workdays(year: int, month: int) -> int:
+    """Return number of working days in given month, considering Chinese holidays and adjusted weekends."""
+    first_day = date(year, month, 1)
+    if month == 12:
+        next_month = date(year + 1, 1, 1)
+    else:
+        next_month = date(year, month + 1, 1)
+
+    d = first_day
+    workdays = 0
+    while d < next_month:
+        if cc.is_workday(d):
+            workdays += 1
+        d += timedelta(days=1)
+    return workdays
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description="Count working days in Chinese calendar, including holidays and adjusted weekends")
+    parser.add_argument("year", type=int, help="Year to calculate")
+    parser.add_argument("-m", "--month", type=int, choices=range(1, 13), help="Optional month (1-12); calculate for entire year if omitted")
+    args = parser.parse_args(argv)
+
+    if args.month:
+        print(f"{args.year}-{args.month:02d}: {count_workdays(args.year, args.month)} workdays")
+    else:
+        for m in range(1, 13):
+            print(f"{args.year}-{m:02d}: {count_workdays(args.year, m)} workdays")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- implement `workdays.py` to compute workdays per month using chinesecalendar
- document usage in README and add requirements

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement chinesecalendar; No matching distribution found)*
- `python workdays.py 2024` *(fails: ModuleNotFoundError: No module named 'chinesecalendar')*

------
https://chatgpt.com/codex/tasks/task_e_689ae3f29938832390441ba737473678